### PR TITLE
Enable nodejs client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Whereas the implemented [client to server](https://github.com/arichiardi/lein-fi
 
 ### To be thorougly tested:
 
-- [ ] Node client
+- [x] Node client
 - [ ] Web-worker client
 - [ ] Trigger of multiple `js-onload`s
 

--- a/src/powerlaces/boot_figreload.clj
+++ b/src/powerlaces/boot_figreload.clj
@@ -66,17 +66,16 @@
 
 (defn- add-init!
   [pod build-config old-spec out-file]
-  (when (not= :nodejs (-> old-spec :compiler-options :target))
-    (io/make-parents out-file)
-    (let [new-spec (pod/with-call-in pod
-                     (powerlaces.boot-figreload.server/add-cljs-edn-init
-                      ~build-config
-                      ~old-spec))]
-      (butil/info "Adding :require(s) to %s...\n" (.getName out-file))
-      (butil/dbug* "%s\n" (butil/pp-str new-spec))
-      (->> new-spec
-           pr-str
-           (spit out-file)))))
+  (io/make-parents out-file)
+  (let [new-spec (pod/with-call-in pod
+                   (powerlaces.boot-figreload.server/add-cljs-edn-init
+                    ~build-config
+                    ~old-spec))]
+    (butil/info "Adding :require(s) to %s...\n" (.getName out-file))
+    (butil/dbug* "%s\n" (butil/pp-str new-spec))
+    (->> new-spec
+         pr-str
+         (spit out-file))))
 
 (defn- relevant-cljs-edns [fileset ids]
   (let [relevant  (map #(str % ".cljs.edn") ids)


### PR DESCRIPTION
Not sure why it was explicitly disabled, but live code reloading just seems to work as expected with this PR.